### PR TITLE
Keep connection alive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ versions.with {
     jedis = '2.6.2'
     mockito = '1.8.5'
     junit = '4.11'
-    spring = '3.2.4.RELEASE'
     commonspool = '1.6'
     commonspool2 = '2.0'
     embeddedredis = '0.5.3.16a1e6d'
@@ -44,8 +43,6 @@ dependencies {
         "org.mockito:mockito-all:$versions.mockito",
         "junit:junit:$versions.junit",
         "org.easytesting:fest-assert:$versions.festassert",
-        "org.springframework:spring-core:$versions.spring",
-        "org.springframework:spring-context:$versions.spring",
         "redis.embedded:embedded-redis:$versions.embeddedredis",
     )
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ group = 'redis.clients'
 
 versions.with {
     guava = '18.0'
-    jedis = '2.6.2'
+    jedis = '2.7.0'
     mockito = '1.8.5'
     junit = '4.11'
     commonspool = '1.6'

--- a/build.gradle
+++ b/build.gradle
@@ -23,13 +23,13 @@ group = 'redis.clients'
 
 versions.with {
     guava = '18.0'
-    jedis = '2.6.0'
+    jedis = '2.6.2'
     mockito = '1.8.5'
     junit = '4.11'
     spring = '3.2.4.RELEASE'
     commonspool = '1.6'
     commonspool2 = '2.0'
-    embeddedredis = '0.5.2.b86e331'
+    embeddedredis = '0.5.3.16a1e6d'
     festassert = '1.4'
 }
 

--- a/src/main/java/redis/clients/jedis/HostMaster.java
+++ b/src/main/java/redis/clients/jedis/HostMaster.java
@@ -7,16 +7,16 @@ public class HostMaster {
     private final HostAndPort hostAndPort;
     private final String name;
 
+    public HostMaster(HostAndPort hostAndPort, String name) {
+        this.hostAndPort = hostAndPort;
+        this.name = name;
+    }
+
     public HostAndPort getHostAndPort() {
         return hostAndPort;
     }
 
     public String getName() {
         return name;
-    }
-
-    HostMaster(HostAndPort hostAndPort, String name) {
-        this.hostAndPort = hostAndPort;
-        this.name = name;
     }
 }

--- a/src/main/java/redis/clients/jedis/HostMaster.java
+++ b/src/main/java/redis/clients/jedis/HostMaster.java
@@ -3,7 +3,7 @@ package redis.clients.jedis;
 /**
 * Created by piotrturek on 29/03/15.
 */
-class HostMaster {
+public class HostMaster {
     private final HostAndPort hostAndPort;
     private final String name;
 

--- a/src/main/java/redis/clients/jedis/HostMaster.java
+++ b/src/main/java/redis/clients/jedis/HostMaster.java
@@ -1,0 +1,22 @@
+package redis.clients.jedis;
+
+/**
+* Created by piotrturek on 29/03/15.
+*/
+class HostMaster {
+    private final HostAndPort hostAndPort;
+    private final String name;
+
+    public HostAndPort getHostAndPort() {
+        return hostAndPort;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    HostMaster(HostAndPort hostAndPort, String name) {
+        this.hostAndPort = hostAndPort;
+        this.name = name;
+    }
+}

--- a/src/main/java/redis/clients/jedis/JedisPubSubAdapter.java
+++ b/src/main/java/redis/clients/jedis/JedisPubSubAdapter.java
@@ -1,0 +1,30 @@
+package redis.clients.jedis;
+
+/**
+* Created by piotrturek on 29/03/15.
+*/
+class JedisPubSubAdapter extends JedisPubSub {
+    @Override
+    public void onMessage(String channel, String message) {
+    }
+
+    @Override
+    public void onPMessage(String pattern, String channel, String message) {
+    }
+
+    @Override
+    public void onPSubscribe(String pattern, int subscribedChannels) {
+    }
+
+    @Override
+    public void onPUnsubscribe(String pattern, int subscribedChannels) {
+    }
+
+    @Override
+    public void onSubscribe(String channel, int subscribedChannels) {
+    }
+
+    @Override
+    public void onUnsubscribe(String channel, int subscribedChannels) {
+    }
+}

--- a/src/main/java/redis/clients/jedis/JedisPubSubAdapter.java
+++ b/src/main/java/redis/clients/jedis/JedisPubSubAdapter.java
@@ -3,7 +3,7 @@ package redis.clients.jedis;
 /**
 * Created by piotrturek on 29/03/15.
 */
-class JedisPubSubAdapter extends JedisPubSub {
+public class JedisPubSubAdapter extends JedisPubSub {
     @Override
     public void onMessage(String channel, String message) {
     }

--- a/src/main/java/redis/clients/jedis/MasterListener.java
+++ b/src/main/java/redis/clients/jedis/MasterListener.java
@@ -1,0 +1,122 @@
+package redis.clients.jedis;
+
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+* Created by piotrturek on 29/03/15.
+*/
+class MasterListener extends Thread {
+
+    private ShardedJedisSentinelPool shardedJedisSentinelPool;
+    protected List<String> masters;
+    protected String host;
+    protected int port;
+    protected long subscribeRetryWaitTimeMillis = 5000;
+    protected Jedis jedis;
+    protected AtomicBoolean running = new AtomicBoolean(false);
+
+    protected MasterListener(ShardedJedisSentinelPool shardedJedisSentinelPool) {
+        this.shardedJedisSentinelPool = shardedJedisSentinelPool;
+    }
+
+    public MasterListener(ShardedJedisSentinelPool shardedJedisSentinelPool, List<String> masters, String host, int port) {
+        this.shardedJedisSentinelPool = shardedJedisSentinelPool;
+        this.masters = masters;
+        this.host = host;
+        this.port = port;
+    }
+
+    public MasterListener(ShardedJedisSentinelPool shardedJedisSentinelPool, List<String> masters, String host, int port,
+						  long subscribeRetryWaitTimeMillis) {
+        this(shardedJedisSentinelPool, masters, host, port);
+        this.subscribeRetryWaitTimeMillis = subscribeRetryWaitTimeMillis;
+    }
+
+    public void run() {
+
+        running.set(true);
+
+        while (running.get()) {
+
+        jedis = new Jedis(host, port);
+        try {
+            jedis.subscribe(new JedisPubSubAdapter() {
+                @Override
+                public void onMessage(String channel, String message) {
+                    shardedJedisSentinelPool.log.info("Sentinel " + host + ":" + port + " published: " + message + ".");
+
+                    String[] switchMasterMsg = message.split(" ");
+
+                    if (switchMasterMsg.length > 3) {
+
+                        int index = masters.indexOf(switchMasterMsg[0]);
+                        if (index >= 0) {
+                            HostAndPort newHostAndPort = shardedJedisSentinelPool.toHostAndPort(Arrays.asList(switchMasterMsg[3], switchMasterMsg[4]));
+                            HostMaster newHostMaster = new HostMaster(newHostAndPort, masters.get(index));
+                            List<HostMaster> newHostMasters = new ArrayList<>();
+                            for (int i = 0; i < masters.size(); i++) {
+                                newHostMasters.add(null);
+                            }
+                            Collections.copy(newHostMasters, shardedJedisSentinelPool.currentHostMasters);
+                            newHostMasters.set(index, newHostMaster);
+
+                            shardedJedisSentinelPool.initPool(newHostMasters);
+                        } else {
+                            StringBuffer sb = new StringBuffer();
+                            for (String masterName : masters) {
+                                sb.append(masterName);
+                                sb.append(",");
+                            }
+                            shardedJedisSentinelPool.log.info("Ignoring message on +switch-master for master name "
+                                    + switchMasterMsg[0]
+                                    + ", our monitor master name are ["
+                                    + sb + "]");
+                        }
+
+                    } else {
+                        shardedJedisSentinelPool.log.severe("Invalid message received on Sentinel "
+                            + host
+                            + ":"
+                            + port
+                            + " on channel +switch-master: "
+                            + message);
+                    }
+                }
+            }, "+switch-master");
+
+        } catch (JedisConnectionException e) {
+
+            if (running.get()) {
+                shardedJedisSentinelPool.log.severe("Lost connection to Sentinel at " + host
+                    + ":" + port
+                    + ". Sleeping 5000ms and retrying.");
+                try {
+                    Thread.sleep(subscribeRetryWaitTimeMillis);
+                } catch (InterruptedException e1) {
+                    e1.printStackTrace();
+                }
+            } else {
+                shardedJedisSentinelPool.log.info("Unsubscribing from Sentinel at " + host + ":"
+                        + port);
+            }
+        }
+        }
+    }
+
+    public void shutdown() {
+        try {
+            shardedJedisSentinelPool.log.info("Shutting down listener on " + host + ":" + port);
+            running.set(false);
+            // This isn't good, the Jedis object is not thread safe
+            jedis.disconnect();
+        } catch (Exception e) {
+            shardedJedisSentinelPool.log.severe("Caught exception while shutting down: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/redis/clients/jedis/MasterListenerErrorHandler.java
+++ b/src/main/java/redis/clients/jedis/MasterListenerErrorHandler.java
@@ -1,0 +1,10 @@
+package redis.clients.jedis;
+
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+/**
+ * Created by piotrturek on 30/03/15.
+ */
+public interface MasterListenerErrorHandler {
+    void handleError(JedisConnectionException e, boolean running);
+}

--- a/src/main/java/redis/clients/jedis/ShardedJedisFactory.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedisFactory.java
@@ -1,0 +1,67 @@
+package redis.clients.jedis;
+
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.PooledObjectFactory;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import redis.clients.util.Hashing;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * PoolableObjectFactory custom impl.
+ */
+class ShardedJedisFactory implements PooledObjectFactory<ShardedJedis> {
+    private List<JedisShardInfo> shards;
+    private Hashing algo;
+    private Pattern keyTagPattern;
+
+    public ShardedJedisFactory(List<JedisShardInfo> shards, Hashing algo, Pattern keyTagPattern) {
+        this.shards = shards;
+        this.algo = algo;
+        this.keyTagPattern = keyTagPattern;
+    }
+
+    public PooledObject<ShardedJedis> makeObject() throws Exception {
+        ShardedJedis jedis = new ShardedJedis(shards, algo, keyTagPattern);
+        return new DefaultPooledObject<ShardedJedis>(jedis);
+    }
+
+    public void destroyObject(PooledObject<ShardedJedis> pooledShardedJedis) throws Exception {
+        final ShardedJedis shardedJedis = pooledShardedJedis.getObject();
+        for (Jedis jedis : shardedJedis.getAllShards()) {
+        try {
+            try {
+            jedis.quit();
+            } catch (Exception e) {
+
+            }
+            jedis.disconnect();
+        } catch (Exception e) {
+
+        }
+        }
+    }
+
+    public boolean validateObject(PooledObject<ShardedJedis> pooledShardedJedis) {
+        try {
+        ShardedJedis jedis = pooledShardedJedis.getObject();
+        for (Jedis shard : jedis.getAllShards()) {
+            if (!shard.ping().equals("PONG")) {
+            return false;
+            }
+        }
+        return true;
+        } catch (Exception ex) {
+        return false;
+        }
+    }
+
+    public void activateObject(PooledObject<ShardedJedis> p) throws Exception {
+
+    }
+
+    public void passivateObject(PooledObject<ShardedJedis> p) throws Exception {
+
+    }
+}

--- a/src/main/java/redis/clients/jedis/ShardedJedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedisSentinelPool.java
@@ -87,6 +87,24 @@ public class ShardedJedisSentinelPool extends Pool<ShardedJedis> {
     	return currentHostMasters.stream().map(HostMaster::getHostAndPort).collect(Collectors.toList());
     }
 
+	@Override
+	public ShardedJedis getResource() {
+		ShardedJedis jedis = super.getResource();
+		jedis.setDataSource(this);
+		return jedis;
+	}
+
+	@Override
+	public void returnBrokenResource(final ShardedJedis resource) {
+		returnBrokenResourceObject(resource);
+	}
+
+	@Override
+	public void returnResource(final ShardedJedis resource) {
+		resource.resetState();
+		returnResourceObject(resource);
+	}
+
     void initPool(List<HostMaster> masters) {
     	if (!isPoolInitialized(currentHostMasters, masters)) {
     		StringBuffer sb = new StringBuffer();

--- a/src/main/java/redis/clients/jedis/ShardedJedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedisSentinelPool.java
@@ -1,17 +1,12 @@
 package redis.clients.jedis;
 
-import org.apache.commons.pool2.PooledObject;
-import org.apache.commons.pool2.PooledObjectFactory;
-import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.util.Hashing;
 import redis.clients.util.Pool;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class ShardedJedisSentinelPool extends Pool<ShardedJedis> {
@@ -32,7 +27,7 @@ public class ShardedJedisSentinelPool extends Pool<ShardedJedis> {
 
     protected Set<MasterListener> masterListeners = new HashSet<MasterListener>();
     
-    private volatile List<HostMaster> currentHostMasters;
+    volatile List<HostMaster> currentHostMasters;
     
     public ShardedJedisSentinelPool(List<String> masters, Set<String> sentinels) {
 		this(masters, sentinels, new GenericObjectPoolConfig(),
@@ -89,16 +84,16 @@ public class ShardedJedisSentinelPool extends Pool<ShardedJedis> {
     }
 
     public List<HostAndPort> getCurrentHostMaster() {
-    	return currentHostMasters.stream().map(m -> m.hostAndPort).collect(Collectors.toList());
+    	return currentHostMasters.stream().map(HostMaster::getHostAndPort).collect(Collectors.toList());
     }
 
-    private void initPool(List<HostMaster> masters) {
+    void initPool(List<HostMaster> masters) {
     	if (!isPoolInitialized(currentHostMasters, masters)) {
     		StringBuffer sb = new StringBuffer();
     		for (HostMaster master : masters) {
-    			sb.append(master.hostAndPort.toString());
+    			sb.append(master.getHostAndPort().toString());
 				sb.append("->");
-				sb.append(master.name);
+				sb.append(master.getName());
     			sb.append(" ");
     		}
     		log.info("Created ShardedJedisPool to master at [" + sb.toString() + "]");
@@ -123,8 +118,8 @@ public class ShardedJedisSentinelPool extends Pool<ShardedJedis> {
 	private List<JedisShardInfo> makeShardInfoList(List<HostMaster> masters) {
 		List<JedisShardInfo> shardMasters = new ArrayList<JedisShardInfo>();
 		for (HostMaster master : masters) {
-			JedisShardInfo jedisShardInfo = new JedisShardInfo(master.hostAndPort.getHost(),
-					master.hostAndPort.getPort(), timeout, master.name);
+			JedisShardInfo jedisShardInfo = new JedisShardInfo(master.getHostAndPort().getHost(),
+					master.getHostAndPort().getPort(), timeout, master.getName());
 			jedisShardInfo.setPassword(password);
 			
 			shardMasters.add(jedisShardInfo);
@@ -195,7 +190,7 @@ public class ShardedJedisSentinelPool extends Pool<ShardedJedis> {
 	    	log.info("Starting Sentinel listeners...");
 			for (String sentinel : sentinels) {
 			    final HostAndPort hap = toHostAndPort(Arrays.asList(sentinel.split(":")));
-			    MasterListener masterListener = new MasterListener(masters, hap.getHost(), hap.getPort());
+			    MasterListener masterListener = new MasterListener(this, masters, hap.getHost(), hap.getPort());
 			    masterListeners.add(masterListener);
 			    masterListener.start();
 			}
@@ -204,212 +199,11 @@ public class ShardedJedisSentinelPool extends Pool<ShardedJedis> {
 		return shardMasters;
     }
 
-    private HostAndPort toHostAndPort(List<String> getMasterAddrByNameResult) {
+    HostAndPort toHostAndPort(List<String> getMasterAddrByNameResult) {
     	String host = getMasterAddrByNameResult.get(0);
     	int port = Integer.parseInt(getMasterAddrByNameResult.get(1));
     	
     	return new HostAndPort(host, port);
     }
-    
-    /**
-     * PoolableObjectFactory custom impl.
-     */
-    protected static class ShardedJedisFactory implements PooledObjectFactory<ShardedJedis> {
-		private List<JedisShardInfo> shards;
-		private Hashing algo;
-		private Pattern keyTagPattern;
-	
-		public ShardedJedisFactory(List<JedisShardInfo> shards, Hashing algo, Pattern keyTagPattern) {
-		    this.shards = shards;
-		    this.algo = algo;
-		    this.keyTagPattern = keyTagPattern;
-		}
 
-		public PooledObject<ShardedJedis> makeObject() throws Exception {
-		    ShardedJedis jedis = new ShardedJedis(shards, algo, keyTagPattern);
-		    return new DefaultPooledObject<ShardedJedis>(jedis);
-		}
-	
-		public void destroyObject(PooledObject<ShardedJedis> pooledShardedJedis) throws Exception {
-		    final ShardedJedis shardedJedis = pooledShardedJedis.getObject();
-		    for (Jedis jedis : shardedJedis.getAllShards()) {
-			try {
-			    try {
-				jedis.quit();
-			    } catch (Exception e) {
-			    	
-			    }
-			    jedis.disconnect();
-			} catch (Exception e) {
-	
-			}
-		    }
-		}
-	
-		public boolean validateObject(PooledObject<ShardedJedis> pooledShardedJedis) {
-		    try {
-			ShardedJedis jedis = pooledShardedJedis.getObject();
-			for (Jedis shard : jedis.getAllShards()) {
-			    if (!shard.ping().equals("PONG")) {
-				return false;
-			    }
-			}
-			return true;
-		    } catch (Exception ex) {
-			return false;
-		    }
-		}
-	
-		public void activateObject(PooledObject<ShardedJedis> p) throws Exception {
-	
-		}
-	
-		public void passivateObject(PooledObject<ShardedJedis> p) throws Exception {
-	
-		}
-    }
-
-    protected class JedisPubSubAdapter extends JedisPubSub {
-		@Override
-		public void onMessage(String channel, String message) {
-		}
-	
-		@Override
-		public void onPMessage(String pattern, String channel, String message) {
-		}
-	
-		@Override
-		public void onPSubscribe(String pattern, int subscribedChannels) {
-		}
-	
-		@Override
-		public void onPUnsubscribe(String pattern, int subscribedChannels) {
-		}
-	
-		@Override
-		public void onSubscribe(String channel, int subscribedChannels) {
-		}
-	
-		@Override
-		public void onUnsubscribe(String channel, int subscribedChannels) {
-		}
-    }
-
-    protected class MasterListener extends Thread {
-
-		protected List<String> masters;
-		protected String host;
-		protected int port;
-		protected long subscribeRetryWaitTimeMillis = 5000;
-		protected Jedis jedis;
-		protected AtomicBoolean running = new AtomicBoolean(false);
-	
-		protected MasterListener() {
-		}
-	
-		public MasterListener(List<String> masters, String host, int port) {
-		    this.masters = masters;
-		    this.host = host;
-		    this.port = port;
-		}
-	
-		public MasterListener(List<String> masters, String host, int port,
-			long subscribeRetryWaitTimeMillis) {
-		    this(masters, host, port);
-		    this.subscribeRetryWaitTimeMillis = subscribeRetryWaitTimeMillis;
-		}
-	
-		public void run() {
-	
-		    running.set(true);
-	
-		    while (running.get()) {
-	
-			jedis = new Jedis(host, port);
-	
-			try {
-			    jedis.subscribe(new JedisPubSubAdapter() {
-					@Override
-					public void onMessage(String channel, String message) {
-					    log.fine("Sentinel " + host + ":" + port + " published: " + message + ".");
-		
-					    String[] switchMasterMsg = message.split(" ");
-		
-					    if (switchMasterMsg.length > 3) {
-					    	
-					    	int index = masters.indexOf(switchMasterMsg[0]);
-						    if (index >= 0) {
-						    	HostAndPort newHostAndPort = toHostAndPort(Arrays.asList(switchMasterMsg[3], switchMasterMsg[4]));
-						    	HostMaster newHostMaster = new HostMaster(newHostAndPort, masters.get(index));
-								List<HostMaster> newHostMasters = new ArrayList<>();
-						    	for (int i = 0; i < masters.size(); i++) {
-						    		newHostMasters.add(null);
-						    	}
-						    	Collections.copy(newHostMasters, currentHostMasters);
-						    	newHostMasters.set(index, newHostMaster);
-						    	
-						    	initPool(newHostMasters);
-						    } else {
-						    	StringBuffer sb = new StringBuffer();
-						    	for (String masterName : masters) {
-						    		sb.append(masterName);
-						    		sb.append(",");
-						    	}
-							    log.fine("Ignoring message on +switch-master for master name "
-								    + switchMasterMsg[0]
-								    + ", our monitor master name are ["
-								    + sb + "]");
-							}
-		
-					    } else {
-							log.severe("Invalid message received on Sentinel "
-								+ host
-								+ ":"
-								+ port
-								+ " on channel +switch-master: "
-								+ message);
-					    }
-					}
-			    }, "+switch-master");
-	
-			} catch (JedisConnectionException e) {
-	
-			    if (running.get()) {
-					log.severe("Lost connection to Sentinel at " + host
-						+ ":" + port
-						+ ". Sleeping 5000ms and retrying.");
-					try {
-					    Thread.sleep(subscribeRetryWaitTimeMillis);
-					} catch (InterruptedException e1) {
-					    e1.printStackTrace();
-					}
-			    } else {
-					log.fine("Unsubscribing from Sentinel at " + host + ":"
-						+ port);
-			    }
-			}
-		    }
-		}
-	
-		public void shutdown() {
-		    try {
-				log.fine("Shutting down listener on " + host + ":" + port);
-				running.set(false);
-				// This isn't good, the Jedis object is not thread safe
-				jedis.disconnect();
-		    } catch (Exception e) {
-		    	log.severe("Caught exception while shutting down: " + e.getMessage());
-		    }
-		}
-    }
-
-	private class HostMaster {
-		private final HostAndPort hostAndPort;
-		private final String name;
-
-		private HostMaster(HostAndPort hostAndPort, String name) {
-			this.hostAndPort = hostAndPort;
-			this.name = name;
-		}
-	}
 }

--- a/src/main/java/redis/clients/jedis/errors/SilentErrorHandler.java
+++ b/src/main/java/redis/clients/jedis/errors/SilentErrorHandler.java
@@ -12,7 +12,7 @@ import java.util.logging.Logger;
 public class SilentErrorHandler implements MasterListenerErrorHandler {
     private final Logger log;
     private static final long DEFAULT_SUBSCRIBE_RETRY_WAIT_TIME_MILLIS = 5000;
-    private static final long DEFAULT_SHOUTING_THRESHOLD_MILLIS = 10000;
+    private static final long DEFAULT_SHOUTING_THRESHOLD_MILLIS = 20000;
     private String sentinelDescription;
     private final long subscribeRetryWaitTimeMillis;
     private long shoutingThresholdMillis;
@@ -31,7 +31,7 @@ public class SilentErrorHandler implements MasterListenerErrorHandler {
 
     @Override
     public void handleError(JedisConnectionException exception, boolean running) {
-        final long errorTimeMillis = System.currentTimeMillis();
+        final long errorTimeMillis = System.nanoTime() / 1_000_000;
         final long timeElapsedSinceLastErrorMillis = errorTimeMillis - lastErrorTimeMillis;
         lastErrorTimeMillis = errorTimeMillis;
         if (running) {

--- a/src/main/java/redis/clients/jedis/errors/SilentErrorHandler.java
+++ b/src/main/java/redis/clients/jedis/errors/SilentErrorHandler.java
@@ -1,0 +1,62 @@
+package redis.clients.jedis.errors;
+
+import redis.clients.jedis.MasterListenerErrorHandler;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * Created by piotrturek on 30/03/15.
+ */
+public class SilentErrorHandler implements MasterListenerErrorHandler {
+    private final Logger log;
+    private static final long DEFAULT_SUBSCRIBE_RETRY_WAIT_TIME_MILLIS = 5000;
+    private static final long DEFAULT_SHOUTING_THRESHOLD_MILLIS = 10000;
+    private String sentinelDescription;
+    private final long subscribeRetryWaitTimeMillis;
+    private long shoutingThresholdMillis;
+    private long lastErrorTimeMillis = -1;
+
+    public SilentErrorHandler(String description, Logger log) {
+        this(description, log, DEFAULT_SUBSCRIBE_RETRY_WAIT_TIME_MILLIS, DEFAULT_SHOUTING_THRESHOLD_MILLIS);
+    }
+
+    public SilentErrorHandler(String description, Logger log, long subscribeRetryWaitTimeMillis, long shoutingThresholdMillis) {
+        this.log = log;
+        this.sentinelDescription = description;
+        this.subscribeRetryWaitTimeMillis = subscribeRetryWaitTimeMillis;
+        this.shoutingThresholdMillis = shoutingThresholdMillis;
+    }
+
+    @Override
+    public void handleError(JedisConnectionException exception, boolean running) {
+        final long errorTimeMillis = System.currentTimeMillis();
+        final long timeElapsedSinceLastErrorMillis = errorTimeMillis - lastErrorTimeMillis;
+        lastErrorTimeMillis = errorTimeMillis;
+        if (running) {
+            logConnectionLoss(timeElapsedSinceLastErrorMillis);
+            applySleepPeriod();
+        } else {
+            log.info("Unsubscribing from " + sentinelDescription);
+        }
+    }
+
+    //will log as severe if previous connection loss occurred less than shoutingThresholdMillis
+    private void logConnectionLoss(long timeElapsedSinceLastErrorMillis) {
+        final String msg = "Lost connection to " + sentinelDescription + ". Sleeping 5000ms and retrying.";
+        if (timeElapsedSinceLastErrorMillis <= shoutingThresholdMillis) {
+            log.severe(msg);
+        } else {
+            log.fine(msg);
+        }
+    }
+
+    private void applySleepPeriod() {
+        try {
+            TimeUnit.MILLISECONDS.sleep(subscribeRetryWaitTimeMillis);
+        } catch (InterruptedException e1) {
+            log.info("SilentErrorHandler interrupted while sleeping after connection loss");
+        }
+    }
+}

--- a/src/test/java/redis/clients/jedis/errors/SilentErrorHandlerTest.java
+++ b/src/test/java/redis/clients/jedis/errors/SilentErrorHandlerTest.java
@@ -1,0 +1,73 @@
+package redis.clients.jedis.errors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.internal.verification.Times;
+import org.mockito.runners.MockitoJUnitRunner;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SilentErrorHandlerTest {
+    private static final long SHOUTING_THRESHOLD_MILLIS = 500;
+    private static final long RETRY_WAIT_MILLIS = 200;
+
+    private SilentErrorHandler instance;
+    @Mock
+    private Logger log;
+
+    @Before
+    public void setUp() throws Exception {
+        instance = new SilentErrorHandler("sentinel man", log, RETRY_WAIT_MILLIS, SHOUTING_THRESHOLD_MILLIS);
+        doCallRealMethod().when(log).fine(anyString());
+        doCallRealMethod().when(log).severe(anyString());
+    }
+
+    @Test
+    public void handleErrorShouldNotLogSevereUponFirstFailure() throws Exception {
+        //when
+        instance.handleError(new JedisConnectionException(""), true);
+
+        //then
+        verify(log).fine(anyString());
+    }
+
+    @Test
+    public void handleErrorShouldLogUnsubscribingFromSentinelWhenNotRunning() throws Exception {
+        //when
+        instance.handleError(new JedisConnectionException(""), false);
+
+        //then
+        verify(log).info(anyString());
+    }
+
+    @Test
+    public void handleErrorShouldLogSevereWhenFailingAfterLessThanThreshold() throws Exception {
+        //when
+        instance.handleError(new JedisConnectionException(""), true);
+        instance.handleError(new JedisConnectionException(""), true);
+
+        //then
+        verify(log).fine(anyString());
+        verify(log).severe(anyString());
+    }
+
+    @Test
+    public void handleErrorShouldLogFineWhenFailingAfterMoreThanThreshold() throws Exception {
+        //when
+        instance.handleError(new JedisConnectionException(""), true);
+        TimeUnit.SECONDS.sleep(2);
+        instance.handleError(new JedisConnectionException(""), true);
+
+        //then
+        verify(log, new Times(2)).fine(anyString());
+    }
+}


### PR DESCRIPTION
- bumped jedis version (according to release notes, we can expect "HUGE" performance optimizations :P)
- bumped embedded redis
- removed dependency on Spring
- started to refactor the pool by extracting inner classes outside of this mess
- introduced an error handling strategy to MasterListener and refactored listener a bit
- implemented a simple error handling strategy that logs connection errors as severe only when they occur less than predefined grace period away from the previous failure. otherwise it logs fine. this should handle both the case of a broken Sentinel and silent Rollbar at the same time
- added integration test for master failover to check that this shit actually works :P 
